### PR TITLE
Fix/veirfyta remove quotes

### DIFF
--- a/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
+++ b/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
@@ -29,8 +29,8 @@ class UppaalVerifier extends AbstractVerifier {
 		var Scanner traceReader = null
 		val actualUppaalQuery = uppaalQueryFile.loadString
 		try {
-			// verifyta -t0 -T TestOneComponent.xml asd.q 
-			val command = "verifyta " + parameters + " \"" + uppaalFile.toString + "\" \"" + uppaalQueryFile.canonicalPath + "\""
+			// verifyta -t0 -T TestOneComponent.xml asd.q
+			val command = String.format("verifyta %s %s %s", parameters, uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath)
 			// Executing the command
 			logger.log(Level.INFO, "Executing command: " + command)
 			process =  Runtime.getRuntime().exec(command)

--- a/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
+++ b/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
@@ -29,9 +29,19 @@ class UppaalVerifier extends AbstractVerifier {
 		var Scanner traceReader = null
 		val actualUppaalQuery = uppaalQueryFile.loadString
 		try {
-			// verifyta -t0 -T TestOneComponent.xml asd.q
-			val command = String.format("verifyta %s %s %s", parameters, uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath)
+			// parameter quotation and escape whitespace in paths
+			val isWindows = System.getProperty("os.name").toLowerCase().contains("win")
+			var String command
+			if (isWindows) {
+				command = String.format("verifyta %s \"%s\" \"%s\"", parameters, uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath)
+			} else {
+				val uppaalFilePath = uppaalFile.canonicalPath.replace(" ", "\\ ")
+				val queryFilePath = uppaalQueryFile.canonicalPath.replace(" ", "\\ ")
+				command = String.format("verifyta %s %s %s", parameters, uppaalFilePath, queryFilePath)
+			}
+			
 			// Executing the command
+			// verifyta -t0 -T TestOneComponent.xml asd.q
 			logger.log(Level.INFO, "Executing command: " + command)
 			process =  Runtime.getRuntime().exec(command)
 			val outputStream = process.inputStream


### PR DESCRIPTION
Platform-specific quotation of verifyta parameters and escaping whitespaces in calling verifyta from Java.