### PR TITLE
#15 add --stacktrace argument to call theta

### DIFF
--- a/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
@@ -64,7 +64,7 @@ class ThetaVerifier extends AbstractVerifier {
 			// java -jar %THETA_XSTS_CLI_PATH% --model trafficlight.xsts --property red_green.prop
 			val traceFile = new File(modelFile.traceFile)
 			traceFile.delete // So no invalid/old cex is parsed if this actual process does not generate one 
-			val command = "java -jar " + jar.escapePath + " " + parameters + " --model " + modelFile.canonicalPath.escapePath + " --property " + queryFile.canonicalPath.escapePath + " --cex " + traceFile.canonicalPath.escapePath
+			val command = '''java -jar «jar.escapePath» «parameters» --model «modelFile.canonicalPath.escapePath» --property «queryFile.canonicalPath.escapePath» --cex «traceFile.canonicalPath.escapePath» --stacktrace'''
 			// Executing the command
 			logger.log(Level.INFO, "Executing command: " + command)
 			process = Runtime.getRuntime().exec(command)


### PR DESCRIPTION
It seems so, that since Theta v2.4.0, the `--stacktrace` argument is mandatory, otherwise Theta does not return the cause of the error, if an exception occurs. Instead of the real cause, we get an error message like this:

```
Use --stacktrace for stack trace
java.lang.IllegalArgumentException: Use --stacktrace for stack trace
	at hu.bme.mit.gamma.theta.verification.ThetaVerifier.verifyQuery(ThetaVerifier.java:121)
	at hu.bme.mit.gamma.verification.util.AbstractVerifier.verifyQuery(AbstractVerifier.java:51)
	at hu.bme.mit.gamma.theta.verification.ThetaVerifier.verifyQuery(ThetaVerifier.java:64)
````
However, if Theta is started with the `--stacktrace` argument, then we get the real error message.

@hajduakos Could you confirm, if this observation is correct, please?