### PR TITLE
Replaced space escaping with string array in runtime command exec

### DIFF
--- a/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
+++ b/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
@@ -29,10 +29,10 @@ class UppaalVerifier extends AbstractVerifier {
 		val actualUppaalQuery = uppaalQueryFile.loadString
 		try {
 			// verifyta -t0 -T TestOneComponent.xml asd.q 
-			var String[] command = #["verifyta"] + parameters.split(" ") + #[uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath]
+			val command = #["verifyta"] + parameters.split(" ") + #[uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath]
 			
 			// Executing the command
-			logger.log(Level.INFO, "Executing command: " + command)
+			logger.log(Level.INFO, "Executing command: " + command.join(" "))
 			process =  Runtime.getRuntime().exec(command)
 			val outputStream = process.inputStream
 			val errorStream = process.errorStream

--- a/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
+++ b/plugins/core/hu.bme.mit.gamma.uppaal.verification/src/hu/bme/mit/gamma/uppaal/verification/UppaalVerifier.xtend
@@ -29,7 +29,8 @@ class UppaalVerifier extends AbstractVerifier {
 		val actualUppaalQuery = uppaalQueryFile.loadString
 		try {
 			// verifyta -t0 -T TestOneComponent.xml asd.q 
-			val command = '''verifyta «parameters» «uppaalFile.canonicalPath.escapePath» «uppaalQueryFile.canonicalPath.escapePath»'''
+			var String[] command = #["verifyta"] + parameters.split(" ") + #[uppaalFile.canonicalPath, uppaalQueryFile.canonicalPath]
+			
 			// Executing the command
 			logger.log(Level.INFO, "Executing command: " + command)
 			process =  Runtime.getRuntime().exec(command)

--- a/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
@@ -65,9 +65,9 @@ class ThetaVerifier extends AbstractVerifier {
 			val traceFile = new File(modelFile.traceFile)
 			traceFile.delete // So no invalid/old cex is parsed if this actual process does not generate one
 			traceFile.deleteOnExit // So the cex with this random name does not remain on disk
-			var String[] command = #["java", "-jar", jar] + parameters.split(" ") + #["--model", modelFile.canonicalPath, "--property", queryFile.canonicalPath, "--cex", traceFile.canonicalPath, "--stacktrace"]
+			val command = #["java", "-jar", jar] + parameters.split(" ") + #["--model", modelFile.canonicalPath, "--property", queryFile.canonicalPath, "--cex", traceFile.canonicalPath, "--stacktrace"]
 			// Executing the command
-			logger.log(Level.INFO, "Executing command: " + command)
+			logger.log(Level.INFO, "Executing command: " + command.join(" "))
 			process = Runtime.getRuntime().exec(command)
 			val outputStream = process.inputStream
 			resultReader = new Scanner(outputStream)

--- a/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.theta.verification/src/hu/bme/mit/gamma/theta/verification/ThetaVerifier.xtend
@@ -65,7 +65,7 @@ class ThetaVerifier extends AbstractVerifier {
 			val traceFile = new File(modelFile.traceFile)
 			traceFile.delete // So no invalid/old cex is parsed if this actual process does not generate one
 			traceFile.deleteOnExit // So the cex with this random name does not remain on disk
-			val command = '''java -jar «jar.escapePath» «parameters» --model «modelFile.canonicalPath.escapePath» --property «queryFile.canonicalPath.escapePath» --cex «traceFile.canonicalPath.escapePath» --stacktrace'''
+			var String[] command = #["java", "-jar", jar] + parameters.split(" ") + #["--model", modelFile.canonicalPath, "--property", queryFile.canonicalPath, "--cex", traceFile.canonicalPath, "--stacktrace"]
 			// Executing the command
 			logger.log(Level.INFO, "Executing command: " + command)
 			process = Runtime.getRuntime().exec(command)


### PR DESCRIPTION
Replaced command string with string array to work platform independent.