### PR TITLE
Promela fixes

### DIFF
--- a/plugins/promela/hu.bme.mit.gamma.promela.verification/src/hu/bme/mit/gamma/promela/verification/PromelaVerifier.xtend
+++ b/plugins/promela/hu.bme.mit.gamma.promela.verification/src/hu/bme/mit/gamma/promela/verification/PromelaVerifier.xtend
@@ -113,7 +113,7 @@ class PromelaVerifier extends AbstractVerifier {
 			}
 			fileUtil.saveString(outputFile, outputString.toString)
 			
-			if (firstLine.contains("violated")) {
+			if (firstLine.contains("violated") || firstLine.contains("acceptance cycle")) {
 				super.result = ThreeStateBoolean.FALSE
 			}
 			else if (firstLine.contains("out of memory")) {

--- a/plugins/promela/hu.bme.mit.gamma.xsts.promela.transformation/src/hu/bme/mit/gamma/xsts/promela/transformation/serializer/ModelSerializer.xtend
+++ b/plugins/promela/hu.bme.mit.gamma.xsts.promela.transformation/src/hu/bme/mit/gamma/xsts/promela/transformation/serializer/ModelSerializer.xtend
@@ -268,9 +268,15 @@ class ModelSerializer {
 	'''
 	
 	protected def String serializeAsTrivialBranch(Action action) '''
-		:: «action.serialize» -> atomic {
-			skip
-		}
+		«IF action instanceof AssumeAction»
+			:: «action.serialize» -> atomic {
+				skip
+			}
+		«ELSE»
+			:: true -> atomic {
+				«action.serialize»
+			}
+		«ENDIF»
 	'''
 	//
 	

--- a/plugins/promela/hu.bme.mit.gamma.xsts.promela.transformation/src/hu/bme/mit/gamma/xsts/promela/transformation/serializer/ModelSerializer.xtend
+++ b/plugins/promela/hu.bme.mit.gamma.xsts.promela.transformation/src/hu/bme/mit/gamma/xsts/promela/transformation/serializer/ModelSerializer.xtend
@@ -268,8 +268,8 @@ class ModelSerializer {
 	'''
 	
 	protected def String serializeAsTrivialBranch(Action action) '''
-		:: true -> atomic {
-			«action.serialize»
+		:: «action.serialize» -> atomic {
+			skip
 		}
 	'''
 	//


### PR DESCRIPTION
Added acceptance cycle as result.

Modified trivial branch serialization:
previous version caused unwanted acceptance cycles because of the `true` guard:
```
:: true -> atomic {
    «action.serialize»
}
```
now the guard has to be evaluated at every step, causing valid acceptance cycle counter-examples:
```
:: «action.serialize» -> atomic {
    skip
}
```