### PR TITLE
TimeoutReferenceExpression

### DIFF
--- a/plugins/core/hu.bme.mit.gamma.statechart.language/src/hu/bme/mit/gamma/statechart/language/StatechartLanguage.xtext
+++ b/plugins/core/hu.bme.mit.gamma.statechart.language/src/hu/bme/mit/gamma/statechart/language/StatechartLanguage.xtext
@@ -549,6 +549,13 @@ TimeSpecification returns InterfaceModel::TimeSpecification:
 	value=AdditiveExpression unit=TimeUnit
 ;
 
+@Override
+LiteralExpression returns ExpressionModel::Expression: 
+	super |
+	('time' '(' TimeSpecification ')')
+;
+
+
 enum TimeUnit returns InterfaceModel::TimeUnit:
 	MILLISECOND = 'ms' | SECOND = 's' | HOUR = 'h'
 ;
@@ -654,6 +661,7 @@ PrimaryExpression returns ExpressionModel::Expression:
 	super |
 	EventParameterReferenceExpression |
 	InterfaceParameterReferenceExpression |
+	TimeoutReferenceExpression |
 	( EventReference '::' ) | // Now this are not usable only in triggers
 	StateReferenceExpression
 ;
@@ -668,7 +676,10 @@ EventParameterReferenceExpression returns InterfaceModel::EventParameterReferenc
 InterfaceParameterReferenceExpression returns InterfaceModel::InterfaceParameterReferenceExpression:
 	//this is a placeholder for the language to be unambiguous
 	'this' '.' event=[InterfaceModel::Event] '::' parameter=[ExpressionModel::ParameterDeclaration];
-
+	
+TimeoutReferenceExpression returns TimeoutReferenceExpression:
+	'timeout-elapsed' '(' timeout=[TimeoutDeclaration] ')'
+;
 
 // Action Language Extensions
 

--- a/plugins/core/hu.bme.mit.gamma.statechart.language/src/hu/bme/mit/gamma/statechart/language/StatechartLanguage.xtext
+++ b/plugins/core/hu.bme.mit.gamma.statechart.language/src/hu/bme/mit/gamma/statechart/language/StatechartLanguage.xtext
@@ -552,7 +552,7 @@ TimeSpecification returns InterfaceModel::TimeSpecification:
 @Override
 LiteralExpression returns ExpressionModel::Expression: 
 	super |
-	('time' '(' TimeSpecification ')')
+	('time' TimeSpecification)
 ;
 
 
@@ -678,7 +678,7 @@ InterfaceParameterReferenceExpression returns InterfaceModel::InterfaceParameter
 	'this' '.' event=[InterfaceModel::Event] '::' parameter=[ExpressionModel::ParameterDeclaration];
 	
 TimeoutReferenceExpression returns TimeoutReferenceExpression:
-	'timeout-elapsed' '(' timeout=[TimeoutDeclaration] ')'
+	'time-elapsed' '(' timeout=[TimeoutDeclaration] ')'
 ;
 
 // Action Language Extensions

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/model/interface.ecore
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/model/interface.ecore
@@ -83,7 +83,7 @@
     <eStructuralFeatures xsi:type="ecore:EReference" name="eventReference" lowerBound="1"
         eType="#//EventReference" containment="true"/>
   </eClassifiers>
-  <eClassifiers xsi:type="ecore:EClass" name="TimeSpecification">
+  <eClassifiers xsi:type="ecore:EClass" name="TimeSpecification" eSuperTypes="../../hu.bme.mit.gamma.expression.model/model/expression.ecore#//LiteralExpression">
     <eStructuralFeatures xsi:type="ecore:EReference" name="value" lowerBound="1" eType="ecore:EClass ../../hu.bme.mit.gamma.expression.model/model/expression.ecore#//Expression"
         containment="true"/>
     <eStructuralFeatures xsi:type="ecore:EAttribute" name="unit" lowerBound="1" eType="#//TimeUnit"/>

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/model/statechart.ecore
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/model/statechart.ecore
@@ -160,4 +160,8 @@
   <eClassifiers xsi:type="ecore:EClass" name="StateAnnotation" abstract="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="TransitionAnnotation" abstract="true"/>
   <eClassifiers xsi:type="ecore:EClass" name="TransitionIdAnnotation" eSuperTypes="#//TransitionAnnotation ../../hu.bme.mit.gamma.expression.model/model/expression.ecore#//NamedElement"/>
+  <eClassifiers xsi:type="ecore:EClass" name="TimeoutReferenceExpression" eSuperTypes="../../hu.bme.mit.gamma.expression.model/model/expression.ecore#//ReferenceExpression">
+    <eStructuralFeatures xsi:type="ecore:EReference" name="timeout" lowerBound="1"
+        eType="#//TimeoutDeclaration"/>
+  </eClassifiers>
 </ecore:EPackage>

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/model/statechart.genmodel
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/model/statechart.genmodel
@@ -392,5 +392,8 @@
     <genClasses image="false" ecoreClass="statechart.ecore#//StateAnnotation"/>
     <genClasses image="false" ecoreClass="statechart.ecore#//TransitionAnnotation"/>
     <genClasses ecoreClass="statechart.ecore#//TransitionIdAnnotation"/>
+    <genClasses ecoreClass="statechart.ecore#//TimeoutReferenceExpression">
+      <genFeatures notify="false" createChild="false" propertySortChoices="true" ecoreFeature="ecore:EReference statechart.ecore#//TimeoutReferenceExpression/timeout"/>
+    </genClasses>
   </genPackages>
 </genmodel:GenModel>

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionSerializer.java
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionSerializer.java
@@ -149,23 +149,23 @@ public class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.Expre
 		if (expression instanceof EventParameterReferenceExpression eventParameterReferenceExpression) {
 			return _serialize(eventParameterReferenceExpression);
 		}
-		if (expression instanceof StateReferenceExpression stateReferenceExpression) {
-			return _serialize(stateReferenceExpression);
+		if (expression instanceof StateReferenceExpression reference) {
+			return _serialize(reference);
 		}
-		if (expression instanceof ComponentInstanceReferenceExpression componentInstanceReferenceExpression) {
-			return _serialize(componentInstanceReferenceExpression);
+		if (expression instanceof ComponentInstanceReferenceExpression reference) {
+			return _serialize(reference);
 		}
-		if (expression instanceof ComponentInstanceStateReferenceExpression componentInstanceStateReferenceExpression) {
-			return _serialize(componentInstanceStateReferenceExpression);
+		if (expression instanceof ComponentInstanceStateReferenceExpression reference) {
+			return _serialize(reference);
 		}
-		if (expression instanceof ComponentInstanceVariableReferenceExpression componentInstanceVariableReferenceExpression) {
-			return _serialize(componentInstanceVariableReferenceExpression);
+		if (expression instanceof ComponentInstanceVariableReferenceExpression reference) {
+			return _serialize(reference);
 		}
-		if (expression instanceof ComponentInstanceEventReferenceExpression componentInstanceEventReferenceExpression) {
-			return _serialize(componentInstanceEventReferenceExpression);
+		if (expression instanceof ComponentInstanceEventReferenceExpression reference) {
+			return _serialize(reference);
 		}
-		if (expression instanceof ComponentInstanceEventParameterReferenceExpression componentInstanceEventParameterReferenceExpression) {
-			return _serialize(componentInstanceEventParameterReferenceExpression);
+		if (expression instanceof ComponentInstanceEventParameterReferenceExpression reference) {
+			return _serialize(reference);
 		}
 		if (expression instanceof TimeoutReferenceExpression timeoutReferenceExpression) {
 			return _serialize(timeoutReferenceExpression);

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionSerializer.java
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionSerializer.java
@@ -21,11 +21,14 @@ import hu.bme.mit.gamma.statechart.composite.ComponentInstanceStateReferenceExpr
 import hu.bme.mit.gamma.statechart.composite.ComponentInstanceVariableReferenceExpression;
 import hu.bme.mit.gamma.statechart.derivedfeatures.StatechartModelDerivedFeatures;
 import hu.bme.mit.gamma.statechart.interface_.EventParameterReferenceExpression;
+import hu.bme.mit.gamma.statechart.interface_.TimeSpecification;
+import hu.bme.mit.gamma.statechart.interface_.TimeUnit;
 import hu.bme.mit.gamma.statechart.statechart.AnyPortEventReference;
 import hu.bme.mit.gamma.statechart.statechart.ClockTickReference;
 import hu.bme.mit.gamma.statechart.statechart.PortEventReference;
 import hu.bme.mit.gamma.statechart.statechart.StateReferenceExpression;
 import hu.bme.mit.gamma.statechart.statechart.TimeoutEventReference;
+import hu.bme.mit.gamma.statechart.statechart.TimeoutReferenceExpression;
 
 public class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.ExpressionSerializer {
 	// Singleton
@@ -49,6 +52,25 @@ public class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.Expre
 	
 	protected String _serialize(TimeoutEventReference expression) {
 		return "timeout " + expression.getTimeout().getName();
+	}
+	
+	protected String _serialize(TimeoutReferenceExpression expression) {
+		return expression.getTimeout().getName();
+	}
+	
+	protected String _serialize(TimeSpecification timeSpecification) {
+		return serialize(timeSpecification.getValue()) + " " + _serialize(timeSpecification.getUnit());
+	}
+	
+	protected String _serialize(TimeUnit timeUnit) {
+		switch (timeUnit) {
+		case SECOND:
+			return "s";
+		case MILLISECOND:
+			return "ms";
+		default:
+			throw new IllegalArgumentException("Not known time unit: " + timeUnit);
+		}
 	}
 	
 	//
@@ -127,23 +149,29 @@ public class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.Expre
 		if (expression instanceof EventParameterReferenceExpression eventParameterReferenceExpression) {
 			return _serialize(eventParameterReferenceExpression);
 		}
-		if (expression instanceof StateReferenceExpression) {
-			return _serialize((StateReferenceExpression) expression);
+		if (expression instanceof StateReferenceExpression stateReferenceExpression) {
+			return _serialize(stateReferenceExpression);
 		}
-		if (expression instanceof ComponentInstanceReferenceExpression) {
-			return _serialize((ComponentInstanceReferenceExpression) expression);
+		if (expression instanceof ComponentInstanceReferenceExpression componentInstanceReferenceExpression) {
+			return _serialize(componentInstanceReferenceExpression);
 		}
-		if (expression instanceof ComponentInstanceStateReferenceExpression) {
-			return _serialize((ComponentInstanceStateReferenceExpression) expression);
+		if (expression instanceof ComponentInstanceStateReferenceExpression componentInstanceStateReferenceExpression) {
+			return _serialize(componentInstanceStateReferenceExpression);
 		}
-		if (expression instanceof ComponentInstanceVariableReferenceExpression) {
-			return _serialize((ComponentInstanceVariableReferenceExpression) expression);
+		if (expression instanceof ComponentInstanceVariableReferenceExpression componentInstanceVariableReferenceExpression) {
+			return _serialize(componentInstanceVariableReferenceExpression);
 		}
-		if (expression instanceof ComponentInstanceEventReferenceExpression) {
-			return _serialize((ComponentInstanceEventReferenceExpression) expression);
+		if (expression instanceof ComponentInstanceEventReferenceExpression componentInstanceEventReferenceExpression) {
+			return _serialize(componentInstanceEventReferenceExpression);
 		}
-		if (expression instanceof ComponentInstanceEventParameterReferenceExpression) {
-			return _serialize((ComponentInstanceEventParameterReferenceExpression) expression);
+		if (expression instanceof ComponentInstanceEventParameterReferenceExpression componentInstanceEventParameterReferenceExpression) {
+			return _serialize(componentInstanceEventParameterReferenceExpression);
+		}
+		if (expression instanceof TimeoutReferenceExpression timeoutReferenceExpression) {
+			return _serialize(timeoutReferenceExpression);
+		}
+		if (expression instanceof TimeSpecification timeSpecification) {
+			return _serialize(timeSpecification);
 		}
 		return super.serialize(expression);
 	}

--- a/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionTypeDeterminator.java
+++ b/plugins/core/hu.bme.mit.gamma.statechart.model/src/hu/bme/mit/gamma/statechart/util/ExpressionTypeDeterminator.java
@@ -20,7 +20,9 @@ import hu.bme.mit.gamma.statechart.composite.ComponentInstanceEventParameterRefe
 import hu.bme.mit.gamma.statechart.composite.ComponentInstanceVariableReferenceExpression;
 import hu.bme.mit.gamma.statechart.interface_.EventParameterReferenceExpression;
 import hu.bme.mit.gamma.statechart.interface_.InterfaceParameterReferenceExpression;
+import hu.bme.mit.gamma.statechart.interface_.TimeSpecification;
 import hu.bme.mit.gamma.statechart.statechart.StateReferenceExpression;
+import hu.bme.mit.gamma.statechart.statechart.TimeoutReferenceExpression;
 
 public class ExpressionTypeDeterminator extends ExpressionTypeDeterminator2 {
 	// Singleton
@@ -42,6 +44,12 @@ public class ExpressionTypeDeterminator extends ExpressionTypeDeterminator2 {
 			ParameterDeclaration parameter = referenceExpression.getParameter();
 			Type type = parameter.getType();
 			return ecoreUtil.clone(type);
+		}
+		else if (expression instanceof TimeoutReferenceExpression) {
+			return factory.createIntegerTypeDefinition();
+		}
+		else if (expression instanceof TimeSpecification) {
+			return factory.createIntegerTypeDefinition();
 		}
 		else if (expression instanceof ComponentInstanceVariableReferenceExpression reference) {
 			VariableDeclaration variable = reference.getVariableDeclaration();

--- a/plugins/xsts/hu.bme.mit.gamma.statechart.lowlevel.transformation/src/hu/bme/mit/gamma/statechart/lowlevel/transformation/ExpressionTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.statechart.lowlevel.transformation/src/hu/bme/mit/gamma/statechart/lowlevel/transformation/ExpressionTransformer.xtend
@@ -230,6 +230,12 @@ class ExpressionTransformer {
 		return expression.transformReferenceExpression.filter(Expression).toList // "Cast" to List<Expression>
 	}
 	
+	def dispatch List<Expression> transformExpression(TimeSpecification timeSpecification) {
+		return #[
+			timeSpecification.timeInMilliseconds.transformSimpleExpression
+		]
+	}
+	
 	// Key method: reference expression
 	
 	def List<ReferenceExpression> transformReferenceExpression(ReferenceExpression expression) {

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.transformation.util/src/hu/bme/mit/gamma/xsts/transformation/serializer/ExpressionSerializer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.transformation.util/src/hu/bme/mit/gamma/xsts/transformation/serializer/ExpressionSerializer.xtend
@@ -22,6 +22,8 @@ import hu.bme.mit.gamma.expression.model.NotExpression
 import hu.bme.mit.gamma.expression.util.ExpressionTypeDeterminator2
 
 import static extension hu.bme.mit.gamma.expression.derivedfeatures.ExpressionModelDerivedFeatures.*
+import hu.bme.mit.gamma.statechart.statechart.TimeoutReferenceExpression
+import hu.bme.mit.gamma.expression.model.Expression
 
 class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.ExpressionSerializer {
 	// Singleton
@@ -56,6 +58,16 @@ class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.ExpressionSe
 //		}
 		
 		return '''«declaration.name»'''
+	}
+	
+	def String serialize(TimeoutReferenceExpression expression) '''«expression.timeout.name»'''
+	
+	override String serialize(Expression expression) {
+		if (expression instanceof TimeoutReferenceExpression) {
+			return expression.serialize
+		} else {
+			return super.serialize(expression)
+		}
 	}
 	
 }

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.transformation.util/src/hu/bme/mit/gamma/xsts/transformation/serializer/ExpressionSerializer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.transformation.util/src/hu/bme/mit/gamma/xsts/transformation/serializer/ExpressionSerializer.xtend
@@ -16,14 +16,14 @@ import hu.bme.mit.gamma.expression.model.DirectReferenceExpression
 import hu.bme.mit.gamma.expression.model.DivExpression
 import hu.bme.mit.gamma.expression.model.ElseExpression
 import hu.bme.mit.gamma.expression.model.EnumerationLiteralExpression
+import hu.bme.mit.gamma.expression.model.Expression
 import hu.bme.mit.gamma.expression.model.IfThenElseExpression
 import hu.bme.mit.gamma.expression.model.ModExpression
 import hu.bme.mit.gamma.expression.model.NotExpression
 import hu.bme.mit.gamma.expression.util.ExpressionTypeDeterminator2
+import hu.bme.mit.gamma.statechart.statechart.TimeoutReferenceExpression
 
 import static extension hu.bme.mit.gamma.expression.derivedfeatures.ExpressionModelDerivedFeatures.*
-import hu.bme.mit.gamma.statechart.statechart.TimeoutReferenceExpression
-import hu.bme.mit.gamma.expression.model.Expression
 
 class ExpressionSerializer extends hu.bme.mit.gamma.expression.util.ExpressionSerializer {
 	// Singleton


### PR DESCRIPTION
Added _TimeoutReferenceExpression_, now _timeouts_ can be referenced in expressions. 
_TimeSpecification_ is now a _LiteralExpression_, so expressions can contain _TimeSpecifications_.
Additional refactoring.