### PR TITLE
Change condition for transforming guards in XSTS-UPPAAL transformer

### DIFF
--- a/plugins/core/hu.bme.mit.gamma.uppaal.util/src/hu/bme/mit/gamma/uppaal/util/ClockExpressionHandler.xtend
+++ b/plugins/core/hu.bme.mit.gamma.uppaal.util/src/hu/bme/mit/gamma/uppaal/util/ClockExpressionHandler.xtend
@@ -56,7 +56,7 @@ class ClockExpressionHandler {
 		return expression !== null &&
 			expression.getSelfAndAllContentsOfType(LogicalExpression)
 				.filter[it.operator == LogicalOperator.OR]
-				.exists[it.firstExpr.containsClockReference &&
+				.exists[it.firstExpr.containsClockReference ||
 						it.secondExpr.containsClockReference]
 	}
 	


### PR DESCRIPTION
The XSTS-UPPAAL transformer can produce invalid UPPAAL models due to non-convex clock guards, which prevents verification.  According to the [UPPAAL documentation](https://docs.uppaal.org/language-reference/system-description/templates/edges/#guards), _'A guard must be a conjunction of simple conditions on clocks, differences between clocks, and boolean expressions not involving clocks.'_

The existing implementation incorrectly transforms guards containing clock variables within disjunctions. The UPPAAL specification strictly prohibits disjunctions involving clocks on either side, although UPPAAL may not always enforce this, particularly with top-level `||` operators.

This PR modifies only the helper function that determines whether transformation is necessary, it does not alter the transformation logic for edges and guards themselves.
