### PR TITLE
Rethink transformation of edges containing guards with clock variables in the XSTS-UPPAAL transformer

### DIFF
--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/CfaActionTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/CfaActionTransformer.xtend
@@ -37,6 +37,7 @@ import static hu.bme.mit.gamma.uppaal.util.XstsNamings.*
 import static extension de.uni_paderborn.uppaal.derivedfeatures.UppaalModelDerivedFeatures.*
 import static extension hu.bme.mit.gamma.expression.derivedfeatures.ExpressionModelDerivedFeatures.*
 import static extension java.lang.Math.*
+import hu.bme.mit.gamma.expression.model.Expression
 
 class CfaActionTransformer {
 	
@@ -145,18 +146,7 @@ class CfaActionTransformer {
 	}
 	
 	protected def dispatch Location transformAction(AssumeAction action, Location source) {
-		val target = createLocation(source.parentTemplate) => [
-			it.name = nextCommittedLocationName
-			it.locationTimeKind = LocationKind.COMMITED
-		]
-		val guards = action.assumption.splitByDisjunction.map[transform]
-		for (guard : guards) {
-			source.createEdge(target) => [
-				it.guard = guard
-			]
-		}
-
-		return target
+		return action.assumption.transformGuard(source)
 	}
 	
 	protected def dispatch Location transformAction(SequentialAction action, Location source) {
@@ -200,30 +190,12 @@ class CfaActionTransformer {
 		val negativeCondition = condition.clone
 				.createNotExpression
 		
-		val thenGuardTarget = createLocation(source.parentTemplate) => [
-			it.name = nextCommittedLocationName
-			it.locationTimeKind = LocationKind.COMMITED
-		]
-		val thenGuards = positiveCondition.splitByDisjunction.map[transform]
-		for (guard : thenGuards) {
-			source.createEdge(thenGuardTarget) => [
-				it.guard = guard
-			]
-		}
+		val thenGuardTarget = positiveCondition.transformGuard(source)
 		
 		val thenAction = action.then
 		val thenActionTarget = thenAction.transformAction(thenGuardTarget)
 		
-		val elseGuardTarget = createLocation(source.parentTemplate) => [
-			it.name = nextCommittedLocationName
-			it.locationTimeKind = LocationKind.COMMITED
-		]
-		val elseGuards = negativeCondition.splitByDisjunction.map[transform]
-		for (guard : elseGuards) {
-			source.createEdge(elseGuardTarget) => [
-				it.guard = guard
-			]
-		}
+		val elseGuardTarget = negativeCondition.transformGuard(source)
 		
 		val elseAction = action.^else
 		val elseActionTarget = (elseAction !== null) ? elseAction.transformAction(elseGuardTarget) : elseGuardTarget
@@ -293,6 +265,20 @@ class CfaActionTransformer {
 		for (transientVariable : transientVariables) {
 			edge.update += transientVariable.createResetingAssignmentExpression
 		}
+	}
+	
+	protected def Location transformGuard(Expression guard, Location source){
+		val target = createLocation(source.parentTemplate) => [
+			it.name = nextCommittedLocationName
+			it.locationTimeKind = LocationKind.COMMITED
+		]
+		val transformedGuards = guard.splitByDisjunction.map[transform]
+		for (transformedGuard : transformedGuards) {
+			source.createEdge(target) => [
+				it.guard = transformedGuard
+			]
+		}
+		return target
 	}
 	
 //	// Variable binding

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/CfaActionTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/CfaActionTransformer.xtend
@@ -53,6 +53,8 @@ class CfaActionTransformer {
 	protected final extension ExpressionEvaluator evaluator = ExpressionEvaluator.INSTANCE
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	
+	protected final extension ClockGuardTransformer clockGuardTransformer = ClockGuardTransformer.INSTANCE
+	
 	new(NtaBuilder ntaBuilder, Traceability traceability) {
 		this.ntaBuilder = ntaBuilder
 		this.traceability = traceability
@@ -143,11 +145,18 @@ class CfaActionTransformer {
 	}
 	
 	protected def dispatch Location transformAction(AssumeAction action, Location source) {
-		val edge = source.createEdgeCommittedSource(nextCommittedLocationName)
-		val uppaalExpression = action.assumption.transform
-		edge.guard = uppaalExpression
-		
-		return edge.target
+		val target = createLocation(source.parentTemplate) => [
+			it.name = nextCommittedLocationName
+			it.locationTimeKind = LocationKind.COMMITED
+		]
+		val guards = action.assumption.splitByDisjunction.map[transform]
+		for (guard : guards) {
+			source.createEdge(target) => [
+				it.guard = guard
+			]
+		}
+
+		return target
 	}
 	
 	protected def dispatch Location transformAction(SequentialAction action, Location source) {
@@ -187,23 +196,37 @@ class CfaActionTransformer {
 		
 		val condition = action.condition
 		
-		val positiveCondition = condition.transform
+		val positiveCondition = condition
 		val negativeCondition = condition.clone
-				.createNotExpression.transform
+				.createNotExpression
 		
-		val thenEdge = source.createEdgeCommittedSource(nextCommittedLocationName)
-		thenEdge.guard = positiveCondition
-		val thenEdgeTarget = thenEdge.target
+		val thenGuardTarget = createLocation(source.parentTemplate) => [
+			it.name = nextCommittedLocationName
+			it.locationTimeKind = LocationKind.COMMITED
+		]
+		val thenGuards = positiveCondition.splitByDisjunction.map[transform]
+		for (guard : thenGuards) {
+			source.createEdge(thenGuardTarget) => [
+				it.guard = guard
+			]
+		}
 		
 		val thenAction = action.then
-		val thenActionTarget = thenAction.transformAction(thenEdgeTarget)
+		val thenActionTarget = thenAction.transformAction(thenGuardTarget)
 		
-		val elseEdge = source.createEdgeCommittedSource(nextCommittedLocationName)
-		elseEdge.guard = negativeCondition
-		val elseEdgeTarget = elseEdge.target
+		val elseGuardTarget = createLocation(source.parentTemplate) => [
+			it.name = nextCommittedLocationName
+			it.locationTimeKind = LocationKind.COMMITED
+		]
+		val elseGuards = negativeCondition.splitByDisjunction.map[transform]
+		for (guard : elseGuards) {
+			source.createEdge(elseGuardTarget) => [
+				it.guard = guard
+			]
+		}
 		
 		val elseAction = action.^else
-		val elseActionTarget = (elseAction !== null) ? elseAction.transformAction(elseEdgeTarget) : elseEdgeTarget
+		val elseActionTarget = (elseAction !== null) ? elseAction.transformAction(elseGuardTarget) : elseGuardTarget
 		
 		elseActionTarget.createEdge(thenActionTarget)
 		

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -21,7 +21,8 @@ class ClockGuardTransformer {
 
 	def /*List<Expression>*/ splitByDisjunction(Expression guard) {
 		try {
-			guard.toDnf
+			val res = guard.clone.toDnf
+			true
 		} catch (Exception e) {
 		}
 	}
@@ -29,20 +30,22 @@ class ClockGuardTransformer {
 	private dispatch def Expression toDnf(Expression exp) {
 		throw new IllegalArgumentException("Unhandled parameter types: " + exp);
 	}
-	
-	private dispatch def Expression toDnf(ReferenceExpression exp){
+
+	private dispatch def Expression toDnf(ReferenceExpression exp) {
 		return exp
-    }
-	private dispatch def Expression toDnf(LiteralExpression exp){
+	}
+
+	private dispatch def Expression toDnf(LiteralExpression exp) {
 		return exp
-    }
-	private dispatch def Expression toDnf(PredicateExpression exp){
+	}
+
+	private dispatch def Expression toDnf(PredicateExpression exp) {
 		return exp
-    }
+	}
 
 	private dispatch def Expression toDnf(NotExpression expr) {
 		val innerExpr = expr.operand
-		
+
 		// A => A
 		if (innerExpr instanceof ReferenceExpression || innerExpr instanceof LiteralExpression ||
 			innerExpr instanceof PredicateExpression) {
@@ -55,22 +58,83 @@ class ClockGuardTransformer {
 		}
 		// not (A and B) => (not A or not B)
 		if (innerExpr instanceof AndExpression) {
-			createOrExpression => [
+			return createOrExpression => [
 				it.operands += innerExpr.operands.map [
-					return toDnf(it.negate)
+					toDnf(it.negate)
 				]
 			]
 		}
 
 		// not (A or B) => (not A and not B)
 		if (innerExpr instanceof OrExpression) {
-			createAndExpression => [
+			return createAndExpression => [
 				it.operands += innerExpr.operands.map [
-					return toDnf(it.negate)
+					toDnf(it.negate)
 				]
 			]
 		}
 
 		throw new IllegalArgumentException("Unhandled parameter types: " + expr);
+	}
+
+	private dispatch def Expression toDnf(AndExpression expr) {
+		val operands = expr.operands.map[toDnf]
+
+		return distributeAnd(operands)
+	}
+
+	/**
+	 * This method may be used to distribute ANDs over ORs.
+	 * 
+	 * @param operands list of operands
+	 * 
+	 * @returns if distribution was necessary an `OrExpression`, otherwise an `AndExpression` 
+	 */
+	private def Expression distributeAnd(List<Expression> operands) {
+		if (!operands.exists[it instanceof OrExpression]) {
+			return createAndExpression => [
+				it.operands += operands
+			]
+		}
+		val listOfOperands = operands.map [
+			if (it instanceof OrExpression) {
+				return it.operands
+			}
+			return #[it]
+		]
+		val product = listProduct(listOfOperands).map [ ops |
+			createAndExpression => [
+				it.operands += ops
+			]
+		]
+
+		return createOrExpression => [
+			it.operands += product
+		]
+	}
+
+	/**
+	 * Creates a product of the inner lists
+	 * 
+	 * @param list list of lists where each inner list must have at least 1 element
+	 * 
+	 * @return every possible combination of the inner lists
+	 */
+	private def List<List<Expression>> listProduct(List<List<Expression>> list) {
+		if (list.empty) {
+			return #[]
+		}
+		if (list.length == 1) {
+			return list.head.map[#[it]]
+		}
+		val tails = listProduct(list.tail.clone)
+		// combine each current expression with each possible tail
+		return list.head.flatMap [ expr |
+			tails.map [ tail |
+				val product = newArrayList(expr.clone)
+				product += tail.clone
+				product
+			]
+		].clone
 	}
 }

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -19,21 +19,25 @@ class ClockGuardTransformer {
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ExpressionModelFactory constraintFactory = ExpressionModelFactory.eINSTANCE
 	protected final extension ExpressionNegator expressionNegator = ExpressionNegator.INSTANCE
-	
-	protected final extension ExpressionSerializer expressionSerializer=ExpressionSerializer.INSTANCE
-		protected final Logger logger = Logger.getLogger("GammaLogger")
-	
+
+	protected final extension ExpressionSerializer expressionSerializer = ExpressionSerializer.INSTANCE
+	protected final Logger logger = Logger.getLogger("GammaLogger")
 
 	public static final ClockGuardTransformer INSTANCE = new ClockGuardTransformer
 
-	def /*List<Expression>*/ splitByDisjunction(Expression guard) {
-		try {
-			val clone=guard.clone
-			val preservedClone=guard.clone
-			val res = clone.toDnf
-			logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «res.serialize»''')
-		} catch (Exception e) {
+	def List<Expression> splitByDisjunction(Expression guard) {
+		val clone = guard.clone
+		val preservedClone = guard.clone
+		if (preservedClone.serialize ==
+			"!((((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Oldas_4) && ((I_CR_h_In_hValue_coid != MyBool::_1) || (I_FT_h_In_hValue_coid != MyBool::_1))) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_nem_fut_5) && (I_CR_h_In_hValue_coid == MyBool::_1) && (I_FT_h_In_hValue_coid == MyBool::_1)) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_fut_8) && (499 <= P_COIDH_Timeout_coid) && (I_CR_h_In_hValue_coid == MyBool::_1) && (I_FT_h_In_hValue_coid == MyBool::_1)) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_fut_8) && ((I_CR_h_In_hValue_coid != MyBool::_1) || (I_FT_h_In_hValue_coid != MyBool::_1)))))") {
+			logger.log(Level.INFO, "foo")
 		}
+		val transformed = clone.toDnf
+		logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «transformed.serialize»''')
+		if (transformed instanceof OrExpression) {
+			return transformed.operands
+		}
+		return #[transformed]
 	}
 
 	private dispatch def Expression toDnf(Expression exp) {
@@ -41,49 +45,27 @@ class ClockGuardTransformer {
 	}
 
 	private dispatch def Expression toDnf(ReferenceExpression exp) {
-		return exp
+		return exp.clone
 	}
 
 	private dispatch def Expression toDnf(LiteralExpression exp) {
-		return exp
+		return exp.clone
 	}
 
 	private dispatch def Expression toDnf(PredicateExpression exp) {
-		return exp
+		return exp.clone
 	}
 
 	private dispatch def Expression toDnf(NotExpression expr) {
 		val innerExpr = expr.operand
 
-		// A => A
-		if (innerExpr instanceof ReferenceExpression || innerExpr instanceof LiteralExpression ||
-			innerExpr instanceof PredicateExpression) {
-			return expr
+		// not A => not A
+		// necessary to avoid infinite recursion
+		if (innerExpr instanceof ReferenceExpression) {
+			return expr.clone
 		}
-
-		// not not A => A
-		if (innerExpr instanceof NotExpression) {
-			return toDnf(innerExpr.operand)
-		}
-		// not (A and B) => (not A or not B)
-		if (innerExpr instanceof AndExpression) {
-			return createOrExpression => [
-				it.operands += innerExpr.operands.map [
-					toDnf(it.negate)
-				]
-			]
-		}
-
-		// not (A or B) => (not A and not B)
-		if (innerExpr instanceof OrExpression) {
-			return createAndExpression => [
-				it.operands += innerExpr.operands.map [
-					toDnf(it.negate)
-				]
-			]
-		}
-
-		throw new IllegalArgumentException("Unhandled parameter types: " + expr);
+		// handles DeMorgan transformations
+		return innerExpr.negate.toDnf
 	}
 
 	private dispatch def Expression toDnf(AndExpression expr) {
@@ -91,19 +73,19 @@ class ClockGuardTransformer {
 
 		return distributeAnd(operands)
 	}
-	
-	private dispatch def Expression toDnf(OrExpression expr){
-		val operands=expr.operands.map[toDnf]
-		
-		val flattenedOperands=operands.flatMap[
-			if(it instanceof OrExpression){
+
+	private dispatch def Expression toDnf(OrExpression expr) {
+		val operands = expr.operands.map[toDnf]
+
+		val flattenedOperands = operands.flatMap [
+			if (it instanceof OrExpression) {
 				return it.operands
 			}
 			return #[it]
 		]
-		
-		return createOrExpression=>[
-			it.operands+=flattenedOperands
+
+		return createOrExpression => [
+			it.operands += flattenedOperands.clone
 		]
 	}
 

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -29,9 +29,21 @@ class ClockGuardTransformer {
 	private dispatch def Expression toDnf(Expression exp) {
 		throw new IllegalArgumentException("Unhandled parameter types: " + exp);
 	}
+	
+	private dispatch def Expression toDnf(ReferenceExpression exp){
+		return exp
+    }
+	private dispatch def Expression toDnf(LiteralExpression exp){
+		return exp
+    }
+	private dispatch def Expression toDnf(PredicateExpression exp){
+		return exp
+    }
 
 	private dispatch def Expression toDnf(NotExpression expr) {
 		val innerExpr = expr.operand
+		
+		// A => A
 		if (innerExpr instanceof ReferenceExpression || innerExpr instanceof LiteralExpression ||
 			innerExpr instanceof PredicateExpression) {
 			return expr

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -34,7 +34,9 @@ class ClockGuardTransformer {
 	protected final extension ExpressionSerializer expressionSerializer = ExpressionSerializer.INSTANCE
 	protected final Logger logger = Logger.getLogger("GammaLogger")
 
-	/// Singleton class instance
+	/**
+	 *  Singleton class instance
+	 */
 	public static final ClockGuardTransformer INSTANCE = new ClockGuardTransformer
 
 	/**
@@ -54,7 +56,7 @@ class ClockGuardTransformer {
 		}
 		return #[transformed]
 	}
-	
+
 	/**
 	 * Function to transform expression into DNF form only if it contains references to clock variables.
 	 * 

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -1,0 +1,64 @@
+package hu.bme.mit.gamma.xsts.uppaal.transformation
+
+import hu.bme.mit.gamma.expression.model.Expression
+import java.util.List
+import hu.bme.mit.gamma.expression.model.NotExpression
+import hu.bme.mit.gamma.util.GammaEcoreUtil
+import hu.bme.mit.gamma.expression.model.AndExpression
+import hu.bme.mit.gamma.expression.model.ExpressionModelFactory
+import hu.bme.mit.gamma.expression.model.OrExpression
+import hu.bme.mit.gamma.expression.model.ReferenceExpression
+import hu.bme.mit.gamma.expression.model.LiteralExpression
+import hu.bme.mit.gamma.expression.model.PredicateExpression
+import hu.bme.mit.gamma.expression.util.ExpressionNegator
+
+class ClockGuardTransformer {
+	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
+	protected final extension ExpressionModelFactory constraintFactory = ExpressionModelFactory.eINSTANCE
+	protected final extension ExpressionNegator expressionNegator = ExpressionNegator.INSTANCE
+
+	public static final ClockGuardTransformer INSTANCE = new ClockGuardTransformer
+
+	def /*List<Expression>*/ splitByDisjunction(Expression guard) {
+		try {
+			guard.toDnf
+		} catch (Exception e) {
+		}
+	}
+
+	private dispatch def Expression toDnf(Expression exp) {
+		throw new IllegalArgumentException("Unhandled parameter types: " + exp);
+	}
+
+	private dispatch def Expression toDnf(NotExpression expr) {
+		val innerExpr = expr.operand
+		if (innerExpr instanceof ReferenceExpression || innerExpr instanceof LiteralExpression ||
+			innerExpr instanceof PredicateExpression) {
+			return expr
+		}
+
+		// not not A => A
+		if (innerExpr instanceof NotExpression) {
+			return toDnf(innerExpr.operand)
+		}
+		// not (A and B) => (not A or not B)
+		if (innerExpr instanceof AndExpression) {
+			createOrExpression => [
+				it.operands += innerExpr.operands.map [
+					return toDnf(it.negate)
+				]
+			]
+		}
+
+		// not (A or B) => (not A and not B)
+		if (innerExpr instanceof OrExpression) {
+			createAndExpression => [
+				it.operands += innerExpr.operands.map [
+					return toDnf(it.negate)
+				]
+			]
+		}
+
+		throw new IllegalArgumentException("Unhandled parameter types: " + expr);
+	}
+}

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -28,10 +28,6 @@ class ClockGuardTransformer {
 	def List<Expression> splitByDisjunction(Expression guard) {
 		val clone = guard.clone
 		val preservedClone = guard.clone
-		if (preservedClone.serialize ==
-			"!((((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Oldas_4) && ((I_CR_h_In_hValue_coid != MyBool::_1) || (I_FT_h_In_hValue_coid != MyBool::_1))) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_nem_fut_5) && (I_CR_h_In_hValue_coid == MyBool::_1) && (I_FT_h_In_hValue_coid == MyBool::_1)) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_fut_8) && (499 <= P_COIDH_Timeout_coid) && (I_CR_h_In_hValue_coid == MyBool::_1) && (I_FT_h_In_hValue_coid == MyBool::_1)) || ((main_region_of_bJbCOID_allapotgep_coid == Main_region_of_bJbCOID_allapotgep_bJbCOID_allapotgep::Celoldas_idozites_fut_8) && ((I_CR_h_In_hValue_coid != MyBool::_1) || (I_FT_h_In_hValue_coid != MyBool::_1)))))") {
-			logger.log(Level.INFO, "foo")
-		}
 		val transformed = clone.toDnf
 		logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «transformed.serialize»''')
 		if (transformed instanceof OrExpression) {

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -1,4 +1,14 @@
-package hu.bme.mit.gamma.xsts.uppaal.transformation
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Gamma project
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * SPDX-License-Identifier: EPL-1.0
+ ********************************************************************************/
+ package hu.bme.mit.gamma.xsts.uppaal.transformation
 
 import hu.bme.mit.gamma.expression.model.AndExpression
 import hu.bme.mit.gamma.expression.model.ClockVariableDeclarationAnnotation

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -11,18 +11,27 @@ import hu.bme.mit.gamma.expression.model.ReferenceExpression
 import hu.bme.mit.gamma.expression.model.LiteralExpression
 import hu.bme.mit.gamma.expression.model.PredicateExpression
 import hu.bme.mit.gamma.expression.util.ExpressionNegator
+import hu.bme.mit.gamma.expression.util.ExpressionSerializer
+import java.util.logging.Logger
+import java.util.logging.Level
 
 class ClockGuardTransformer {
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ExpressionModelFactory constraintFactory = ExpressionModelFactory.eINSTANCE
 	protected final extension ExpressionNegator expressionNegator = ExpressionNegator.INSTANCE
+	
+	protected final extension ExpressionSerializer expressionSerializer=ExpressionSerializer.INSTANCE
+		protected final Logger logger = Logger.getLogger("GammaLogger")
+	
 
 	public static final ClockGuardTransformer INSTANCE = new ClockGuardTransformer
 
 	def /*List<Expression>*/ splitByDisjunction(Expression guard) {
 		try {
-			val res = guard.clone.toDnf
-			true
+			val clone=guard.clone
+			val preservedClone=guard.clone
+			val res = clone.toDnf
+			logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «res.serialize»''')
 		} catch (Exception e) {
 		}
 	}
@@ -82,13 +91,28 @@ class ClockGuardTransformer {
 
 		return distributeAnd(operands)
 	}
+	
+	private dispatch def Expression toDnf(OrExpression expr){
+		val operands=expr.operands.map[toDnf]
+		
+		val flattenedOperands=operands.flatMap[
+			if(it instanceof OrExpression){
+				return it.operands
+			}
+			return #[it]
+		]
+		
+		return createOrExpression=>[
+			it.operands+=flattenedOperands
+		]
+	}
 
 	/**
 	 * This method may be used to distribute ANDs over ORs.
 	 * 
 	 * @param operands list of operands
 	 * 
-	 * @returns if distribution was necessary an `OrExpression`, otherwise an `AndExpression` 
+	 * @returns if distribution was necessary an `OrExpression`, otherwise an #[list.head]`AndExpression` 
 	 */
 	private def Expression distributeAnd(List<Expression> operands) {
 		if (!operands.exists[it instanceof OrExpression]) {

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -14,11 +14,16 @@ import hu.bme.mit.gamma.expression.util.ExpressionNegator
 import hu.bme.mit.gamma.expression.util.ExpressionSerializer
 import java.util.logging.Logger
 import java.util.logging.Level
+import hu.bme.mit.gamma.expression.util.ExpressionEvaluator
+import hu.bme.mit.gamma.expression.model.DirectReferenceExpression
+import hu.bme.mit.gamma.expression.model.VariableDeclaration
+import hu.bme.mit.gamma.expression.model.ClockVariableDeclarationAnnotation
 
 class ClockGuardTransformer {
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ExpressionModelFactory constraintFactory = ExpressionModelFactory.eINSTANCE
 	protected final extension ExpressionNegator expressionNegator = ExpressionNegator.INSTANCE
+	protected final extension ExpressionEvaluator expressionEvaluator = ExpressionEvaluator.INSTANCE
 
 	protected final extension ExpressionSerializer expressionSerializer = ExpressionSerializer.INSTANCE
 	protected final Logger logger = Logger.getLogger("GammaLogger")
@@ -28,12 +33,19 @@ class ClockGuardTransformer {
 	def List<Expression> splitByDisjunction(Expression guard) {
 		val clone = guard.clone
 		val preservedClone = guard.clone
-		val transformed = clone.toDnf
+		val transformed = clone.toDnfChecked
 		logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «transformed.serialize»''')
 		if (transformed instanceof OrExpression) {
-			return transformed.operands
+			return transformed.operands.reject[it.isDefinitelyFalseExpression].clone
 		}
 		return #[transformed]
+	}
+
+	private def Expression toDnfChecked(Expression exp) {
+		if (exp.containsClockReference) {
+			return toDnf(exp)
+		}
+		return exp.clone
 	}
 
 	private dispatch def Expression toDnf(Expression exp) {
@@ -61,17 +73,17 @@ class ClockGuardTransformer {
 			return expr.clone
 		}
 		// handles DeMorgan transformations
-		return innerExpr.negate.toDnf
+		return innerExpr.negate.toDnfChecked
 	}
 
 	private dispatch def Expression toDnf(AndExpression expr) {
-		val operands = expr.operands.map[toDnf]
+		val operands = expr.operands.map[toDnfChecked]
 
 		return distributeAnd(operands)
 	}
 
 	private dispatch def Expression toDnf(OrExpression expr) {
-		val operands = expr.operands.map[toDnf]
+		val operands = expr.operands.map[toDnfChecked]
 
 		val flattenedOperands = operands.flatMap [
 			if (it instanceof OrExpression) {
@@ -138,5 +150,19 @@ class ClockGuardTransformer {
 				product
 			]
 		].clone
+	}
+
+	private def containsClockReference(Expression expression) {
+		return expression !== null && expression.getSelfAndAllContentsOfType(DirectReferenceExpression).exists [
+			it.clock
+		]
+	}
+
+	private def boolean isClock(DirectReferenceExpression expr) {
+		val declaration = expr.declaration
+		if (declaration instanceof VariableDeclaration) {
+			return declaration.annotations.exists[it instanceof ClockVariableDeclarationAnnotation]
+		}
+		return false
 	}
 }

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -19,6 +19,14 @@ import hu.bme.mit.gamma.expression.model.DirectReferenceExpression
 import hu.bme.mit.gamma.expression.model.VariableDeclaration
 import hu.bme.mit.gamma.expression.model.ClockVariableDeclarationAnnotation
 
+
+/**
+ * A utility class that brings guard expressions to DNF form in regard to clock variables.
+ * 
+ * UPPAAL requires, that 'A guard must be a conjunction of simple conditions on clocks, 
+ * differences between clocks, and boolean expressions not involving clocks.'
+ * This class can bring an expression to DNF form so it may be split across edges. 
+ */
 class ClockGuardTransformer {
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ExpressionModelFactory constraintFactory = ExpressionModelFactory.eINSTANCE
@@ -28,19 +36,33 @@ class ClockGuardTransformer {
 	protected final extension ExpressionSerializer expressionSerializer = ExpressionSerializer.INSTANCE
 	protected final Logger logger = Logger.getLogger("GammaLogger")
 
+	/// Singleton class instance
 	public static final ClockGuardTransformer INSTANCE = new ClockGuardTransformer
 
+	/**
+	 * Split expression into expressions, which used as parallel edges are equivalent to the original.
+	 * Clock comparisons may only be in the top level of the expression by itself or in a top level `and` expression.
+	 * 
+	 * @param guard expression can only contain: AndExpression, LiteralExpression, NotExpression, OrExpression, 
+	 * 	PredicateExpression, ReferenceExpression
+	 * 
+	 * @return List of expressions. May be empty if all created expressions are definitely false.
+	 */
 	def List<Expression> splitByDisjunction(Expression guard) {
 		val clone = guard.clone
-		val preservedClone = guard.clone
 		val transformed = clone.toDnfChecked
-		logger.log(Level.INFO, '''Before: «preservedClone.serialize»; After: «transformed.serialize»''')
+		logger.log(Level.INFO, '''Before: «guard.serialize»; After: «transformed.serialize»''')
 		if (transformed instanceof OrExpression) {
 			return transformed.operands.reject[it.isDefinitelyFalseExpression].clone
 		}
 		return #[transformed]
 	}
-
+	
+	/**
+	 * Function to transform expression into DNF form only if it contains references to clock variables.
+	 * 
+	 * @param exp Limitations listed at splitByDisjunction
+	 */
 	private def Expression toDnfChecked(Expression exp) {
 		if (exp.containsClockReference) {
 			return toDnf(exp)
@@ -48,6 +70,10 @@ class ClockGuardTransformer {
 		return exp.clone
 	}
 
+	/**
+	 * Dispatch recursive function (through toDnfChecked) to bring an expression into DNF form. 
+	 * @param exp Limitations listed at splitByDisjunction
+	 */
 	private dispatch def Expression toDnf(Expression exp) {
 		throw new IllegalArgumentException("Unhandled parameter types: " + exp);
 	}
@@ -85,6 +111,8 @@ class ClockGuardTransformer {
 	private dispatch def Expression toDnf(OrExpression expr) {
 		val operands = expr.operands.map[toDnfChecked]
 
+		// Bring up inner `or`s
+		// A or (B or C) => A or B or C
 		val flattenedOperands = operands.flatMap [
 			if (it instanceof OrExpression) {
 				return it.operands
@@ -100,9 +128,9 @@ class ClockGuardTransformer {
 	/**
 	 * This method may be used to distribute ANDs over ORs.
 	 * 
-	 * @param operands list of operands
+	 * @param operands list of operands of the original AND expression. Doesn't have to contain any ORs.
 	 * 
-	 * @returns if distribution was necessary an `OrExpression`, otherwise an #[list.head]`AndExpression` 
+	 * @returns if distribution was necessary an `OrExpression`, otherwise an `AndExpression` 
 	 */
 	private def Expression distributeAnd(List<Expression> operands) {
 		if (!operands.exists[it instanceof OrExpression]) {
@@ -152,12 +180,18 @@ class ClockGuardTransformer {
 		].clone
 	}
 
+	/**
+	 * Check if the expression contains a reference to a clock variable
+	 */
 	private def containsClockReference(Expression expression) {
 		return expression !== null && expression.getSelfAndAllContentsOfType(DirectReferenceExpression).exists [
 			it.clock
 		]
 	}
 
+	/**
+	 * Check if the referenced variable is a clock
+	 */
 	private def boolean isClock(DirectReferenceExpression expr) {
 		val declaration = expr.declaration
 		if (declaration instanceof VariableDeclaration) {

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/ClockGuardTransformer.xtend
@@ -1,24 +1,22 @@
 package hu.bme.mit.gamma.xsts.uppaal.transformation
 
-import hu.bme.mit.gamma.expression.model.Expression
-import java.util.List
-import hu.bme.mit.gamma.expression.model.NotExpression
-import hu.bme.mit.gamma.util.GammaEcoreUtil
 import hu.bme.mit.gamma.expression.model.AndExpression
+import hu.bme.mit.gamma.expression.model.ClockVariableDeclarationAnnotation
+import hu.bme.mit.gamma.expression.model.DirectReferenceExpression
+import hu.bme.mit.gamma.expression.model.Expression
 import hu.bme.mit.gamma.expression.model.ExpressionModelFactory
-import hu.bme.mit.gamma.expression.model.OrExpression
-import hu.bme.mit.gamma.expression.model.ReferenceExpression
 import hu.bme.mit.gamma.expression.model.LiteralExpression
+import hu.bme.mit.gamma.expression.model.NotExpression
+import hu.bme.mit.gamma.expression.model.OrExpression
 import hu.bme.mit.gamma.expression.model.PredicateExpression
+import hu.bme.mit.gamma.expression.model.ReferenceExpression
+import hu.bme.mit.gamma.expression.model.VariableDeclaration
+import hu.bme.mit.gamma.expression.util.ExpressionEvaluator
 import hu.bme.mit.gamma.expression.util.ExpressionNegator
 import hu.bme.mit.gamma.expression.util.ExpressionSerializer
+import hu.bme.mit.gamma.util.GammaEcoreUtil
+import java.util.List
 import java.util.logging.Logger
-import java.util.logging.Level
-import hu.bme.mit.gamma.expression.util.ExpressionEvaluator
-import hu.bme.mit.gamma.expression.model.DirectReferenceExpression
-import hu.bme.mit.gamma.expression.model.VariableDeclaration
-import hu.bme.mit.gamma.expression.model.ClockVariableDeclarationAnnotation
-
 
 /**
  * A utility class that brings guard expressions to DNF form in regard to clock variables.
@@ -51,7 +49,6 @@ class ClockGuardTransformer {
 	def List<Expression> splitByDisjunction(Expression guard) {
 		val clone = guard.clone
 		val transformed = clone.toDnfChecked
-		logger.log(Level.INFO, '''Before: «guard.serialize»; After: «transformed.serialize»''')
 		if (transformed instanceof OrExpression) {
 			return transformed.operands.reject[it.isDefinitelyFalseExpression].clone
 		}

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
@@ -1,11 +1,11 @@
 /********************************************************************************
  * Copyright (c) 2018-2023 Contributors to the Gamma project
- *
+ * 
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * SPDX-License-Identifier: EPL-1.0
  ********************************************************************************/
 package hu.bme.mit.gamma.xsts.uppaal.transformation
@@ -26,22 +26,22 @@ import static hu.bme.mit.gamma.uppaal.util.XstsNamings.*
 import static extension hu.bme.mit.gamma.xsts.derivedfeatures.XstsDerivedFeatures.*
 
 class XstsToUppaalTransformer {
-	
+
 	protected final XSTS xSts
 	protected final Traceability traceability
-	
+
 	// Auxiliary
 	protected final extension NtaBuilder ntaBuilder
 	protected final extension CfaActionTransformer actionTransformer
 	protected final extension FunctionActionTransformer functionctionTransformer
 	protected final extension VariableTransformer variableTransformer
 	protected final extension NtaOptimizer ntaOptimizer
-	
+
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ClockExpressionHandler clockExpressionHandler = ClockExpressionHandler.INSTANCE
-	
+
 	protected final Logger logger = Logger.getLogger("GammaLogger")
-	
+
 	new(XSTS xSts) {
 		this.xSts = xSts
 		this.ntaBuilder = new NtaBuilder(xSts.name, false)
@@ -51,63 +51,69 @@ class XstsToUppaalTransformer {
 		this.variableTransformer = new VariableTransformer(ntaBuilder, traceability)
 		this.ntaOptimizer = new NtaOptimizer(ntaBuilder)
 	}
-	
+
 	def execute() {
 		// If the XSTS transformation extracts guards into local variables:
 		// if the guard contains clock variables (referencing native clocks), they should be reinlined
-		
 		resetCommittedLocationName
 		val initialLocation = templateName.createTemplateWithInitLoc(initialLocationName)
 		initialLocation.locationTimeKind = LocationKind.COMMITED
 		val template = initialLocation.parentTemplate
-		
+
 		val initializingAction = xSts.initializingAction
 		val environmentalAction = xSts.environmentalAction
 		val mergedAction = xSts.mergedAction
-		
+
 		xSts.transformVariables
-		
+
 		val stableLocation = initializingAction.transformAction(initialLocation)
 		stableLocation.name = stableLocationName
 		stableLocation.locationTimeKind = LocationKind.NORMAL
-		
+
 		val environmentFinishLocation = template.createLocation
 		environmentFinishLocation.name = environmentFinishLocationName
 		// Location kind is Normal, so optimization does not delete it
 		environmentalAction.transformIntoCfa(stableLocation, environmentFinishLocation)
-		
-		if (mergedAction.isOrContainsTypes(#[NonDeterministicAction, HavocAction]) ||
-				xSts.hasClockVariable || xSts.hasInvariants) {
+
+		if (mergedAction.isOrContainsTypes(#[NonDeterministicAction, HavocAction]) || xSts.hasClockVariable ||
+			xSts.hasInvariants) {
 			// For nondeterministic cases, UPPAAL functions cannot be used
 			mergedAction.transformIntoCfa(environmentFinishLocation, stableLocation)
-		}
-		else {
+		} else {
 			// Deterministic behavior, creating a function
 			mergedAction.transformIntoFunction(environmentFinishLocation, stableLocation)
 		}
-		
+
 		// Optimizing edges from these location
+		val before=ntaBuilder.nta.template.head.location.length
 		initialLocation.optimizeSubsequentEdges
+		val afterInit=ntaBuilder.nta.template.head.location.length
 		stableLocation.optimizeSubsequentEdges
+		val afterStable=ntaBuilder.nta.template.head.location.length
 		environmentFinishLocation.optimizeSubsequentEdges
+		val afterEnv=ntaBuilder.nta.template.head.location.length
 		
+		if(afterInit!=afterStable||afterStable!=afterEnv){
+			logger.log(Level.INFO, "hmmmm")
+		}
+
 		if (environmentFinishLocation !== stableLocation) {
 			// Model checking is faster if the environment finish location is committed
 			environmentFinishLocation.locationTimeKind = LocationKind.COMMITED
 		}
-		
+
 		logger.log(Level.INFO, "Basic NTA transformation has finished")
-		
+
 		//
 		optimizelIntegerCodomains
 		//
 		val nta = ntaBuilder.nta
-		nta.transformClockExpressions
+		//done during transforIntoCfa
+		//nta.transformClockExpressions
 		//
-		
 		ntaBuilder.instantiateTemplates
-		
+
 		return nta
 	}
-	
+
 }

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
@@ -102,7 +102,7 @@ class XstsToUppaalTransformer {
 		optimizelIntegerCodomains
 		//
 		val nta = ntaBuilder.nta
-		//nta.transformClockExpressions CFA transformer handles it
+		//nta.transformClockExpressions // CFA transformer handles it
 		//
 		
 		ntaBuilder.instantiateTemplates

--- a/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
+++ b/plugins/xsts/hu.bme.mit.gamma.xsts.uppaal.transformation/src/hu/bme/mit/gamma/xsts/uppaal/transformation/XstsToUppaalTransformer.xtend
@@ -1,11 +1,11 @@
 /********************************************************************************
  * Copyright (c) 2018-2023 Contributors to the Gamma project
- * 
+ *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- * 
+ *
  * SPDX-License-Identifier: EPL-1.0
  ********************************************************************************/
 package hu.bme.mit.gamma.xsts.uppaal.transformation
@@ -26,22 +26,22 @@ import static hu.bme.mit.gamma.uppaal.util.XstsNamings.*
 import static extension hu.bme.mit.gamma.xsts.derivedfeatures.XstsDerivedFeatures.*
 
 class XstsToUppaalTransformer {
-
+	
 	protected final XSTS xSts
 	protected final Traceability traceability
-
+	
 	// Auxiliary
 	protected final extension NtaBuilder ntaBuilder
 	protected final extension CfaActionTransformer actionTransformer
 	protected final extension FunctionActionTransformer functionctionTransformer
 	protected final extension VariableTransformer variableTransformer
 	protected final extension NtaOptimizer ntaOptimizer
-
+	
 	protected final extension GammaEcoreUtil ecoreUtil = GammaEcoreUtil.INSTANCE
 	protected final extension ClockExpressionHandler clockExpressionHandler = ClockExpressionHandler.INSTANCE
-
+	
 	protected final Logger logger = Logger.getLogger("GammaLogger")
-
+	
 	new(XSTS xSts) {
 		this.xSts = xSts
 		this.ntaBuilder = new NtaBuilder(xSts.name, false)
@@ -51,69 +51,63 @@ class XstsToUppaalTransformer {
 		this.variableTransformer = new VariableTransformer(ntaBuilder, traceability)
 		this.ntaOptimizer = new NtaOptimizer(ntaBuilder)
 	}
-
+	
 	def execute() {
 		// If the XSTS transformation extracts guards into local variables:
 		// if the guard contains clock variables (referencing native clocks), they should be reinlined
+		
 		resetCommittedLocationName
 		val initialLocation = templateName.createTemplateWithInitLoc(initialLocationName)
 		initialLocation.locationTimeKind = LocationKind.COMMITED
 		val template = initialLocation.parentTemplate
-
+		
 		val initializingAction = xSts.initializingAction
 		val environmentalAction = xSts.environmentalAction
 		val mergedAction = xSts.mergedAction
-
+		
 		xSts.transformVariables
-
+		
 		val stableLocation = initializingAction.transformAction(initialLocation)
 		stableLocation.name = stableLocationName
 		stableLocation.locationTimeKind = LocationKind.NORMAL
-
+		
 		val environmentFinishLocation = template.createLocation
 		environmentFinishLocation.name = environmentFinishLocationName
 		// Location kind is Normal, so optimization does not delete it
 		environmentalAction.transformIntoCfa(stableLocation, environmentFinishLocation)
-
-		if (mergedAction.isOrContainsTypes(#[NonDeterministicAction, HavocAction]) || xSts.hasClockVariable ||
-			xSts.hasInvariants) {
+		
+		if (mergedAction.isOrContainsTypes(#[NonDeterministicAction, HavocAction]) ||
+				xSts.hasClockVariable || xSts.hasInvariants) {
 			// For nondeterministic cases, UPPAAL functions cannot be used
 			mergedAction.transformIntoCfa(environmentFinishLocation, stableLocation)
-		} else {
+		}
+		else {
 			// Deterministic behavior, creating a function
 			mergedAction.transformIntoFunction(environmentFinishLocation, stableLocation)
 		}
-
-		// Optimizing edges from these location
-		val before=ntaBuilder.nta.template.head.location.length
-		initialLocation.optimizeSubsequentEdges
-		val afterInit=ntaBuilder.nta.template.head.location.length
-		stableLocation.optimizeSubsequentEdges
-		val afterStable=ntaBuilder.nta.template.head.location.length
-		environmentFinishLocation.optimizeSubsequentEdges
-		val afterEnv=ntaBuilder.nta.template.head.location.length
 		
-		if(afterInit!=afterStable||afterStable!=afterEnv){
-			logger.log(Level.INFO, "hmmmm")
-		}
-
+		// Optimizing edges from these location
+		initialLocation.optimizeSubsequentEdges
+		stableLocation.optimizeSubsequentEdges
+		environmentFinishLocation.optimizeSubsequentEdges
+		
 		if (environmentFinishLocation !== stableLocation) {
 			// Model checking is faster if the environment finish location is committed
 			environmentFinishLocation.locationTimeKind = LocationKind.COMMITED
 		}
-
+		
 		logger.log(Level.INFO, "Basic NTA transformation has finished")
-
+		
 		//
 		optimizelIntegerCodomains
 		//
 		val nta = ntaBuilder.nta
-		//done during transforIntoCfa
-		//nta.transformClockExpressions
+		//nta.transformClockExpressions CFA transformer handles it
 		//
+		
 		ntaBuilder.instantiateTemplates
-
+		
 		return nta
 	}
-
+	
 }


### PR DESCRIPTION
In the current solution, we first generate the UPPAAL model from the XSTS model without any regard to clocks, perform optimizations on it, then post-process it the following way:

1. Check if the expression contains an OR expression (at any depth), where on either side we reference a clock variable (also at any depth)
2. If yes, then we map our current expression's top level component the following way: 
    - ANDs become an intermediate location, with the operands split between the incoming and outgoing edge
    - ORs become parallel edges with the operands split between them
3. Recursively run step 1 on both created edges.

While this method works, it outputs models with an excessive amount of extra locations and edges, making verification slower. My PR takes a completely different approach.

Handling clock references becomes part of the XSTS to UPPAAL transformation step. Guard expressions are processed by `ClockGuardTransformer`. It brings the expression into DNF form only for clock references, meaning the top level OR's operands are going to be a conjunction of clock comparisons and any non-clock expressions. These operands become guards on parallel edges. As an additional optimization, operands that are definitely false don't produce edges.
